### PR TITLE
Add play area border and on-screen controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
 </head>
 <body>
   <canvas id="game" width="200" height="400"></canvas>
+  <div id="controls">
+    <button id="left" class="control-btn">&#9664;</button>
+    <button id="rotate" class="control-btn">&#8635;</button>
+    <button id="right" class="control-btn">&#9654;</button>
+    <button id="down" class="control-btn">&#9660;</button>
+  </div>
   <script src="script.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/script.js
+++ b/script.js
@@ -190,5 +190,10 @@ document.addEventListener('keydown', e => {
   else if (e.key === 'ArrowUp') playerRotate();
 });
 
+document.getElementById('left').addEventListener('click', () => playerMove(-1));
+document.getElementById('right').addEventListener('click', () => playerMove(1));
+document.getElementById('down').addEventListener('click', playerDrop);
+document.getElementById('rotate').addEventListener('click', playerRotate);
+
 playerReset();
 update();

--- a/style.css
+++ b/style.css
@@ -8,4 +8,18 @@ canvas {
   display: block;
   margin: 0 auto;
   touch-action: none;
+  border: 2px solid grey;
+}
+
+#controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.control-btn {
+  width: 50px;
+  height: 50px;
+  margin: 0 5px;
+  font-size: 24px;
 }


### PR DESCRIPTION
## Summary
- Outline game canvas with a grey border for clearer play area
- Introduce on-screen control buttons for left, right, rotate, and drop actions
- Wire up button handlers in script to control gameplay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab386874cc8332b3f438645e976c00