### PR TITLE
Add play area outline and on-screen controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
 </head>
 <body>
   <canvas id="game" width="200" height="400"></canvas>
+  <div id="controls">
+    <button id="left">◄</button>
+    <button id="rotate">▲</button>
+    <button id="right">►</button>
+    <button id="down">▼</button>
+  </div>
   <script src="script.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/script.js
+++ b/script.js
@@ -190,5 +190,10 @@ document.addEventListener('keydown', e => {
   else if (e.key === 'ArrowUp') playerRotate();
 });
 
+document.getElementById('left').addEventListener('click', () => playerMove(-1));
+document.getElementById('right').addEventListener('click', () => playerMove(1));
+document.getElementById('down').addEventListener('click', playerDrop);
+document.getElementById('rotate').addEventListener('click', playerRotate);
+
 playerReset();
 update();

--- a/style.css
+++ b/style.css
@@ -8,4 +8,24 @@ canvas {
   display: block;
   margin: 0 auto;
   touch-action: none;
+  border: 2px solid grey;
+}
+
+#controls {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 20px;
+}
+
+#controls button {
+  width: 50px;
+  height: 50px;
+  font-size: 24px;
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
 }


### PR DESCRIPTION
## Summary
- Outline the play area with a grey border for better visibility
- Add fixed on-screen control buttons and styling
- Hook up new buttons to existing movement and rotation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab386874cc8332b3f438645e976c00