### PR TITLE
Add next piece preview and swap control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,16 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="game" width="200" height="400"></canvas>
-  <div id="controls">
-    <button id="left" class="control-btn">&#9664;</button>
-    <button id="rotate" class="control-btn">&#8635;</button>
-    <button id="right" class="control-btn">&#9654;</button>
-    <button id="down" class="control-btn">&#9660;</button>
-  </div>
+    <div id="game-area">
+      <canvas id="game" width="200" height="400"></canvas>
+      <canvas id="next" width="80" height="80"></canvas>
+    </div>
+    <div id="controls">
+      <button id="left" class="control-btn">&#9664;</button>
+      <button id="rotate" class="control-btn">&#8635;</button>
+      <button id="down" class="control-btn">&#9660;</button>
+      <button id="right" class="control-btn">&#9654;</button>
+    </div>
   <script src="script.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/script.js
+++ b/script.js
@@ -1,10 +1,15 @@
 const canvas = document.getElementById('game');
 const context = canvas.getContext('2d');
+const nextCanvas = document.getElementById('next');
+const nextContext = nextCanvas.getContext('2d');
 const grid = 20;
 const cols = canvas.width / grid;
 const rows = canvas.height / grid;
+const nextCols = nextCanvas.width / grid;
+const nextRows = nextCanvas.height / grid;
 
 context.scale(grid, grid);
+nextContext.scale(grid, grid);
 
 const shapes = [
   [[1,1,1,1]],
@@ -26,19 +31,30 @@ const player = {
   color: '#FFF'
 };
 
+let next = { matrix: null, color: '#FFF' };
+
 function createPiece(typeIndex) {
   return shapes[typeIndex];
 }
 
-function playerReset() {
+function getRandomPiece() {
   const typeIndex = Math.floor(Math.random() * shapes.length);
-  player.matrix = createPiece(typeIndex);
-  player.color = colors[typeIndex];
+  return { matrix: createPiece(typeIndex), color: colors[typeIndex] };
+}
+
+function playerReset() {
+  if (!next.matrix) {
+    next = getRandomPiece();
+  }
+  player.matrix = next.matrix;
+  player.color = next.color;
   player.pos.y = 0;
   player.pos.x = (cols / 2 | 0) - (player.matrix[0].length / 2 | 0);
   if (collide(arena, player)) {
     arena.forEach(row => row.fill(0));
   }
+  next = getRandomPiece();
+  drawNext();
 }
 
 function collide(arena, player) {
@@ -131,6 +147,23 @@ function drawMatrix(matrix, offset) {
       if (value) {
         context.fillStyle = player.color;
         context.fillRect(x + offset.x, y + offset.y, 1, 1);
+      }
+    });
+  });
+}
+
+function drawNext() {
+  nextContext.fillStyle = '#000';
+  nextContext.fillRect(0, 0, nextCanvas.width, nextCanvas.height);
+  const offset = {
+    x: (nextCols - next.matrix[0].length) / 2,
+    y: (nextRows - next.matrix.length) / 2
+  };
+  next.matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value) {
+        nextContext.fillStyle = next.color;
+        nextContext.fillRect(x + offset.x, y + offset.y, 1, 1);
       }
     });
   });

--- a/style.css
+++ b/style.css
@@ -2,13 +2,25 @@ body {
   margin: 0;
   background: #000;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 canvas {
   display: block;
-  margin: 0 auto;
+  margin: 0;
   touch-action: none;
   border: 2px solid grey;
+}
+
+#game-area {
+  display: flex;
+  align-items: flex-start;
+}
+
+#next {
+  margin-left: 10px;
 }
 
 #controls {


### PR DESCRIPTION
## Summary
- Swap right and down control button positions
- Add next-block preview canvas and supporting logic
- Arrange play area and next block display side-by-side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6937659883329ffea537b868f660