### PR TITLE
Add hard drop and piece swap controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
       <button id="rotate" class="control-btn">&#8635;</button>
       <button id="down" class="control-btn">&#9660;</button>
       <button id="right" class="control-btn">&#9654;</button>
+      <button id="drop" class="control-btn" aria-label="Drop">&#8650;</button>
+      <button id="switch" class="control-btn" aria-label="Switch">&#8646;</button>
     </div>
   <script src="script.js"></script>
   <script>

--- a/script.js
+++ b/script.js
@@ -161,6 +161,34 @@ function playerDrop() {
   dropCounter = 0;
 }
 
+function playerHardDrop() {
+  while (!collide(arena, player)) {
+    player.pos.y++;
+  }
+  player.pos.y--;
+  merge(arena, player);
+  arenaSweep();
+  playerReset();
+  dropCounter = 0;
+}
+
+function playerSwitch() {
+  const tempMatrix = player.matrix;
+  const tempColor = player.color;
+  player.matrix = next.matrix;
+  player.color = next.color;
+  player.pos.y = 0;
+  player.pos.x = (cols / 2 | 0) - (player.matrix[0].length / 2 | 0);
+  if (collide(arena, player)) {
+    arena.forEach(row => row.fill(0));
+    score = 0;
+    updateScore();
+  }
+  next.matrix = tempMatrix;
+  next.color = tempColor;
+  drawNext();
+}
+
 function playerMove(dir) {
   player.pos.x += dir;
   if (collide(arena, player)) {
@@ -244,12 +272,16 @@ document.addEventListener('keydown', e => {
   else if (e.key === 'ArrowRight') playerMove(1);
   else if (e.key === 'ArrowDown') playerDrop();
   else if (e.key === 'ArrowUp') playerRotate();
+  else if (e.code === 'Space') playerHardDrop();
+  else if (e.key === 'Shift') playerSwitch();
 });
 
 document.getElementById('left').addEventListener('click', () => playerMove(-1));
 document.getElementById('right').addEventListener('click', () => playerMove(1));
 document.getElementById('down').addEventListener('click', playerDrop);
 document.getElementById('rotate').addEventListener('click', playerRotate);
+document.getElementById('drop').addEventListener('click', playerHardDrop);
+document.getElementById('switch').addEventListener('click', playerSwitch);
 
 updateScore();
 playerReset();

--- a/style.css
+++ b/style.css
@@ -34,6 +34,7 @@ canvas {
   display: flex;
   justify-content: center;
   margin-top: 10px;
+  flex-wrap: wrap;
 }
 
 .control-btn {
@@ -41,4 +42,18 @@ canvas {
   height: 50px;
   margin: 0 5px;
   font-size: 24px;
+  background: #333;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 5px;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+  cursor: pointer;
 }
+
+.control-btn:active {
+  background: #555;
+}
+


### PR DESCRIPTION
## Summary
- Add hard drop functionality and swap with queued piece
- Expose new drop and switch buttons in UI and key bindings
- Allow controls to wrap on small screens
- Style drop/switch buttons and prevent text selection on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54e6fc0cc8332b0f5e41c4a988a28